### PR TITLE
feat: use stow to manage dotfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,12 @@ stow-uninstall-packages: _treat-warnings-as-errors
 	done; \
 	echo "$(TEXT_OK) Stow uninstalled packages.";
 
+.PHONY: stow-check-badlinks
+stow-check-badlinks: ## Stow check the installed packages in $HOME directory which
+stow-check-badlinks: ## are bad links.
+stow-check-badlinks: _treat-warnings-as-errors
+	@chkstow --target "$(STOW_USER_HOME)" --badlinks;
+
 _%/$(HOME)/.bash:               SOURCE_PATH = $(PROJECT_DIR)/src/bash
 _%/$(HOME)/.bash_logout:        SOURCE_PATH = $(PROJECT_DIR)/src/bash/bash_logout
 _%/$(HOME)/.bash_profile:       SOURCE_PATH = $(PROJECT_DIR)/src/bash/bash_profile

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,25 @@ stow-install-packages: _treat-warnings-as-errors
 	done; \
 	echo "$(TEXT_OK) Stow installed packages.";
 
+.PHONY: stow-uninstall-packages
+stow-uninstall-packages: ## Stow uninstall packages from $HOME directory.
+stow-uninstall-packages: _treat-warnings-as-errors
+	@echo "$(TEXT_INFO) Stow uninstalling packages from the directory $(STOW_USER_HOME) ..."; \
+	for path in $(STOW_PACKAGES_DIR) $(STOW_PACKAGES_DIR)/dot-*; do \
+		if ! test -d "$${path}"; then \
+			continue; \
+		fi; \
+		dir=$$(dirname "$${path}"); \
+		name=$$(basename "$${path}"); \
+		stow --verbose \
+			--dotfiles \
+			--target "$(STOW_USER_HOME)" \
+			--dir "$${dir}" \
+			--delete "$${name}" \
+			$(STOW_OPTS); \
+	done; \
+	echo "$(TEXT_OK) Stow uninstalled packages.";
+
 _%/$(HOME)/.bash:               SOURCE_PATH = $(PROJECT_DIR)/src/bash
 _%/$(HOME)/.bash_logout:        SOURCE_PATH = $(PROJECT_DIR)/src/bash/bash_logout
 _%/$(HOME)/.bash_profile:       SOURCE_PATH = $(PROJECT_DIR)/src/bash/bash_profile

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,25 @@ stow-refresh-ignore-files: _treat-warnings-as-errors
 		fi; \
 	done;
 
+.PHONY: stow-install-packages
+stow-install-packages: ## Stow install packages into $HOME directory.
+stow-install-packages: _treat-warnings-as-errors
+	@echo "$(TEXT_INFO) Stow installing packages into the directory $(STOW_USER_HOME) ..."; \
+	for path in $(STOW_PACKAGES_DIR) $(STOW_PACKAGES_DIR)/dot-*; do \
+		if ! test -d "$${path}"; then \
+			continue; \
+		fi; \
+		dir=$$(dirname "$${path}"); \
+		name=$$(basename "$${path}"); \
+		stow --verbose \
+			--dotfiles \
+			--target "$(STOW_USER_HOME)" \
+			--dir "$${dir}" \
+			--stow "$${name}" \
+			$(STOW_OPTS); \
+	done; \
+	echo "$(TEXT_OK) Stow installed packages.";
+
 _%/$(HOME)/.bash:               SOURCE_PATH = $(PROJECT_DIR)/src/bash
 _%/$(HOME)/.bash_logout:        SOURCE_PATH = $(PROJECT_DIR)/src/bash/bash_logout
 _%/$(HOME)/.bash_profile:       SOURCE_PATH = $(PROJECT_DIR)/src/bash/bash_profile

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ EXIT_CODE_OK := 0
 EXIT_CODE_GENERAL_ERROR := 1
 
 # Colorful Texts
+# @see https://unix.stackexchange.com/a/10065
 
 TEXT_OK := [OK]
 TEXT_INFO := [INFO]
@@ -26,14 +27,14 @@ IS_COLOR_SUPPORTED := $(shell \
 	fi; \
 )
 ifeq ("$(IS_COLOR_SUPPORTED)", "$(EXIT_CODE_OK)")
-	TEXT_COLOR_NONE := \033[0m
-	TEXT_COLOR_RED := \033[0;31m
-	TEXT_COLOR_GREEN := \033[0;32m
-	TEXT_COLOR_CYAN := \033[0;36m
+	TEXT_COLOR_NORMAL := $(shell tput sgr0)
+	TEXT_COLOR_RED := $(shell tput setaf 1)
+	TEXT_COLOR_GREEN := $(shell tput setaf 2)
+	TEXT_COLOR_CYAN := $(shell tput setaf 6)
 
-	TEXT_OK := $(TEXT_COLOR_GREEN)$(TEXT_OK)$(TEXT_COLOR_NONE)
-	TEXT_INFO := $(TEXT_COLOR_CYAN)$(TEXT_INFO)$(TEXT_COLOR_NONE)
-	TEXT_ERROR := $(TEXT_COLOR_RED)$(TEXT_ERROR)$(TEXT_COLOR_NONE)
+	TEXT_OK := $(TEXT_COLOR_GREEN)$(TEXT_OK)$(TEXT_COLOR_NORMAL)
+	TEXT_INFO := $(TEXT_COLOR_CYAN)$(TEXT_INFO)$(TEXT_COLOR_NORMAL)
+	TEXT_ERROR := $(TEXT_COLOR_RED)$(TEXT_ERROR)$(TEXT_COLOR_NORMAL)
 endif
 
 _%/$(HOME)/.bash:               SOURCE_PATH = $(PROJECT_DIR)/src/bash

--- a/src/.stow-local-ignore
+++ b/src/.stow-local-ignore
@@ -1,0 +1,17 @@
+bash
+brew
+ctags
+curl
+fonts
+git
+most
+mycli
+mysql
+npm
+pgcli
+readline
+screen
+ssh
+tig
+tmux
+vim

--- a/src/dot-stowrc.d/dot-stow-global-ignore
+++ b/src/dot-stowrc.d/dot-stow-global-ignore
@@ -1,0 +1,26 @@
+# Git
+
+.git
+.gitattributes
+.gitignore
+.gitkeep
+.gitmodules
+
+# HG
+.hg
+.hgignore
+
+# Stow
+.stow-local-ignore
+.stow
+
+# SVN
+.svn
+
+# MacOS
+.DS_store
+
+# Vim
+.netrwhist
+.swp
+.lock

--- a/src/dot-stowrc.d/dot-stowrc
+++ b/src/dot-stowrc.d/dot-stowrc
@@ -1,0 +1,3 @@
+--verbose
+--dotfiles
+--target=$HOME


### PR DESCRIPTION
## Purpose

> What is the purpose? How the feature works?

Use `stow` to manage dotfiles



### Usage / Example

> Any kind of usage, codes or screenshots as examples.

```bash
# on MacOS
brew install stow
```

```bash
make stow-install-packages
make stow-uninstall-packages
make stow-check-badlinks
```

```bash
touch src/dot-stowrc.d/README.md
make stow-refresh-ignore-list
```

### Changes

> A simple summary for important changes.

- [x] feat: use stow to manage dotfiles.
- [x] feat: add .stowrc files
- [x] feat: add `make stow-install-packages` to install dotfiles
- [x] feat: add `make stow-uninstall-packages` to uninstall dotfiles
- [x] feat: add `make stow-refresh-ignore-files` to re-generate ignore list in each stow package

### References

- https://www.gnu.org/software/stow/